### PR TITLE
added example for local host only setup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,10 @@ To start Interlock using the Shipyard API:
 
 `docker run -it -p 80:8080 -d ehazlett/interlock -shipyard-url <your-shipyard-url> -shipyard-service-key <your-shipyard-service-key>`
 
+To start Interlock using the Shipyard API in a local host only setup:
+
+`docker run -it -p 80:8080 -d -v /var/run/docker.sock:/docker.sock ehazlett/interlock -shipyard-url <your-shipyard-url> -shipyard-service-key <your-shipyard-service-key>`
+
 Interlock will query the Shipyard API for a list of engines and then automatically connect and start listening for events.
 
 # Optional Data


### PR DESCRIPTION
To avoid error like this

```
INFO[0000] loaded engine: local                         
INFO[0000] Interlock running proxy=:8080                
FATA[0000] Get http://unix.sock/v1.10/containers/json?all=0: dial unix /docker.sock: no such file or directory
```
