### PR TITLE
Frontend section in HAProxy config file have been splitted in two.

### DIFF
--- a/controller/manager.go
+++ b/controller/manager.go
@@ -44,7 +44,6 @@ defaults
 
 frontend http-default
     bind *:{{ .Config.Port }}
-    {{ if .Config.SSLCert }}bind *:{{ .Config.SSLPort }} ssl crt {{ .Config.SSLCert }} {{ .Config.SSLOpts }}{{ end }}
     monitor-uri /haproxy?monitor
     {{ if .Config.StatsUser }}stats realm Stats
     stats auth {{ .Config.StatsUser }}:{{ .Config.StatsPassword }}{{ end }}

--- a/controller/manager.go
+++ b/controller/manager.go
@@ -51,9 +51,18 @@ frontend http-default
     stats enable
     stats uri /haproxy?stats
     stats refresh 5s
+    reqadd X-Forwarded-Proto:\ http
     {{ range $host := .Hosts }}acl is_{{ $host.Name }} hdr_beg(host) {{ $host.Domain }}
     use_backend {{ $host.Name }} if is_{{ $host.Name }}
     {{ end }}
+{{ if .Config.SSLCert }}
+frontend https-default
+    bind *:{{ .Config.SSLPort }} ssl crt {{ .Config.SSLCert }} {{ .Config.SSLOpts }}
+    reqadd X-Forwarded-Proto:\ https
+    {{ range $host := .Hosts }}acl is_{{ $host.Name }} hdr_beg(host) {{ $host.Domain }}
+    use_backend {{ $host.Name }} if is_{{ $host.Name }}
+    {{ end }}
+{{ end }}
 {{ range $host := .Hosts }}backend {{ $host.Name }}
     http-response add-header X-Request-Start %Ts.%ms
     balance roundrobin


### PR DESCRIPTION
One for  http and for https.

I have also added a **X-Forwarded-Proto** header to the request for identifying the originating protocol of the  request to the  backend.

 It might make sense to make the second change customizable by doing something similar to the already existing backend configuration. By, for example, adding a **frontend_options** to the `INTERLOCK_DATA` JSON and use it to configure HAProxy. 
