### PR TITLE
Allow TLS transport/authentication when connecting to engines

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,5 +29,8 @@ type (
 		SSLOpts            string             `json:"ssl_opts,omitempty"`
 		ShipyardUrl        string             `json:"shipyard_url,omitempty"`
 		ShipyardServiceKey string             `json:"shipyard_service_key,omitempty"`
+		EngineSSLCert      string             `json:"engine_ssl_cert,omitempty"`
+		EngineSSLCACert    string             `json:"engine_ssl_ca_cert,omitempty"`
+		EngineSSLKey       string             `json:"engine_ssl_key,omitempty"`
 	}
 )

--- a/controller/main.go
+++ b/controller/main.go
@@ -20,6 +20,9 @@ var (
 	sslCert            string
 	sslOpts            string
 	sslPort            int
+	engineSslCert      string
+	engineSslCaCert    string
+	engineSslKey       string
 	logger             = logrus.New()
 )
 
@@ -46,6 +49,9 @@ func init() {
 	flag.StringVar(&sslCert, "ssl-cert", "", "path to ssl cert (enables SSL)")
 	flag.IntVar(&sslPort, "ssl-port", 8443, "ssl listen port (must have cert above)")
 	flag.StringVar(&sslOpts, "ssl-opts", "", "string of SSL options (eg. ciphers or tls versions)")
+	flag.StringVar(&engineSslCert, "engine-ssl-cert", "", "Client certificate to use connecting to engines")
+	flag.StringVar(&engineSslKey, "engine-ssl-key", "", "Key to use with engine-ssl-cert")
+	flag.StringVar(&engineSslCaCert, "engine-ssl-cacert", "", "CA Cert to use with engine-ssl-cert")
 	flag.Parse()
 }
 
@@ -56,6 +62,9 @@ func main() {
 	config.Port = proxyPort
 	config.SSLPort = sslPort
 	config.SSLOpts = sslOpts
+	config.EngineSSLCert = engineSslCert
+	config.EngineSSLKey = engineSslKey
+	config.EngineSSLCACert = engineSslCaCert
 	if shipyardUrl == "" {
 		cfg, err := loadConfig()
 		if err != nil {


### PR DESCRIPTION
Currently interlock cannot speak to the engine APIs if the engines (Docker) are running with `tlsverify` (ensure that clients present certificates signed by `tlscacert`).

Also, probably even if `tlsverify` is not used, interlock will probably fail to connect due to x509 validation.

This PR adds options that mirror those that the Docker daemon provides.
