### PR TITLE
add ability to specify arbitrary haproxy lines in backend config

### DIFF
--- a/plugins/haproxy/data.go
+++ b/plugins/haproxy/data.go
@@ -13,4 +13,5 @@ type InterlockData struct {
 	// these are custom vals for hosts
 	Check          string   `json:"check,omitempty"`
 	BackendOptions []string `json:"backend_options,omitempty"`
+	BackendParams  []string `json:"backend_params,omitempty"`
 }

--- a/plugins/haproxy/proxyconfig.go
+++ b/plugins/haproxy/proxyconfig.go
@@ -6,6 +6,7 @@ type (
 		Domain           string
 		Check            string
 		BackendOptions   []string
+		BackendParams    []string
 		Upstreams        []*Upstream
 		SSLOnly          bool
 		BalanceAlgorithm string

--- a/plugins/haproxy/readme.md
+++ b/plugins/haproxy/readme.md
@@ -76,7 +76,8 @@ The following options are available:
 - `alias_domains`: specify a list of alias domains to add (`{"alias_domains": ["foo.com", "bar.com"]}`)
 - `port`: specify which container port to use for backend (`{"port": 8080}`)
 - `check`: specify a custom check for the backend (`{"check": "httpchk GET /"}`)
-- `backend_options`: specify a list of additional options for the backend (`{"backend_options": ["forceclose", "http-no-delay"]}`) -- see http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.1
+- `backend_options`: specify a list of additional options for the backend (`{"backend_options": ["forceclose", "http-no-delay"]}`) -- see http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.1 -- these only work for the keywords that begin with `option`.
+- `backend_params`: specify a list of additional lines for the backend section of the config (`{"backend_params": ["http-request set-header X-Foo Bar"]}`) -- see http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.1 -- this works for anything that can be specified in a 'backend'.
 - `check_interval`: specify the interval (in ms) when to run the health check (`{"check_interval": 10000}`)  default: 5000
 - `ssl_only`: configure redirect to SSL for backend (`{"ssl_only": true}`)
 - `balance_algorithm`: haproxy balancing algorithm (default: `roundrobin`) http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#balance


### PR DESCRIPTION
The ergonomics of this one are admittedly questionable.  The motivation was that I needed to set additional parameters in the backend section (`http_request` in my case).  The closest thing existing seemed to be `backend_options`, but that only worked to add lines that started with `option`.  I left that alone, and added another, similar property, in order to not cause a breaking change.

Ideally, I think the best thing would be to ditch the `backend_options` parameter, and have people explicitly add the word `option` in the config if they need to, but that would obviously break people's existing setup.