### PR TITLE
Fix crash when event Id is less than 12 chars

### DIFF
--- a/interlock/handler.go
+++ b/interlock/handler.go
@@ -22,7 +22,7 @@ func NewEventHandler(mgr *Manager) *EventHandler {
 
 func (l *EventHandler) Handle(e *dockerclient.Event, ec chan error, args ...interface{}) {
 	plugins.Log("interlock", log.DebugLevel,
-		fmt.Sprintf("event: date=%d type=%s image=%s container=%s", e.Time, e.Status, e.From, e.Id[:12]))
+		fmt.Sprintf("event: date=%d type=%s image=%s container=%s", e.Time, e.Status, e.From, e.Id))
 
 	go plugins.DispatchEvent(l.Manager.Config, l.Manager.Client, e, ec)
 }


### PR DESCRIPTION
Was sometimes getting "slice bounds out of range".

May as well print out the whole thing in debug mode. This is
sometimes names instead of IDs depending on the event.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>