### PR TITLE
SSL Backend Support

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.3-cross
+FROM golang:1.4.2-cross
 RUN go get github.com/tools/godep
 ADD . /go/src/github.com/ehazlett/interlock
 ADD https://get.docker.com/builds/Linux/x86_64/docker-1.5.0 /usr/local/bin/docker

--- a/interlock/Dockerfile
+++ b/interlock/Dockerfile
@@ -2,5 +2,5 @@ FROM debian:jessie
 RUN apt-get update
 RUN apt-get install -y haproxy nginx-full ca-certificates --no-install-recommends
 ADD interlock /usr/local/bin/interlock
-EXPOSE 8080 8443
+EXPOSE 80 443
 ENTRYPOINT ["/usr/local/bin/interlock"]

--- a/plugins/haproxy/data.go
+++ b/plugins/haproxy/data.go
@@ -2,13 +2,15 @@ package haproxy
 
 type InterlockData struct {
 	// these are custom vals for upstreams
-	Port             int      `json:"port,omitempty"`
-	AliasDomains     []string `json:"alias_domains,omitempty"`
-	SSLOnly          bool     `json:"ssl_only,omitempty"`
-	CheckInterval    int      `json:"check_interval,omitempty"`
-	Hostname         string   `json:"hostname,omitempty"`
-	Domain           string   `json:"domain,omitempty"`
-	BalanceAlgorithm string   `json:"balance_algorithm,omitempty"`
+	Port                int      `json:"port,omitempty"`
+	AliasDomains        []string `json:"alias_domains,omitempty"`
+	SSLOnly             bool     `json:"ssl_only,omitempty"`
+	SSLBackend          bool     `json:"ssl_backend,omitempty"`
+	SSLBackendTLSVerify string   `json:"ssl_backend_tls_verify,omitempty"`
+	CheckInterval       int      `json:"check_interval,omitempty"`
+	Hostname            string   `json:"hostname,omitempty"`
+	Domain              string   `json:"domain,omitempty"`
+	BalanceAlgorithm    string   `json:"balance_algorithm,omitempty"`
 
 	// these are custom vals for hosts
 	Check          string   `json:"check,omitempty"`

--- a/plugins/haproxy/proxyconfig.go
+++ b/plugins/haproxy/proxyconfig.go
@@ -2,16 +2,18 @@ package haproxy
 
 type (
 	Host struct {
-		Name             string
-		Domain           string
-		Check            string
-		BackendOptions   []string
-		Upstreams        []*Upstream
-		SSLOnly          bool
-		BalanceAlgorithm string
+		Name                string
+		Domain              string
+		Check               string
+		BackendOptions      []string
+		Upstreams           []*Upstream
+		SSLOnly             bool
+		SSLBackend          bool
+		SSLBackendTLSVerify string
+		BalanceAlgorithm    string
 	}
 	Upstream struct {
-                Container     string
+		Container     string
 		Addr          string
 		CheckInterval int
 	}

--- a/plugins/haproxy/readme.md
+++ b/plugins/haproxy/readme.md
@@ -16,7 +16,7 @@ The following configuration is available through environment variables:
 
 - `HAPROXY_PROXY_CONFIG_PATH`: HAProxy generated config file path (default: `/proxy.conf`)
 - `HAPROXY_PROXY_BACKEND_OVERRIDE_ADDRESS`: Manually set the proxy backend address -- this is needed if not using Swarm (i.e. only Docker)
-- `HAPROXY_PORT`: Port to serve (default: `8080`)
+- `HAPROXY_PORT`: Port to serve (default: `80`)
 - `HAPROXY_PID_PATH`: HAProxy pid path
 - `HAPROXY_MAX_CONN`: Max connections (default: `2048`)
 - `HAPROXY_CONNECT_TIMEOUT`: Connection timeout (default: `5000`)
@@ -24,7 +24,7 @@ The following configuration is available through environment variables:
 - `HAPROXY_CLIENT_TIMEOUT`: Client connection timeout (default: `10000`)
 - `HAPROXY_STATS_USER`: HAProxy admin username (default: `stats`)
 - `HAPROXY_STATS_PASSWORD`: HAProxy admin password (default: `interlock`)
-- `HAPROXY_SSL_PORT`: HAProxy SSL port (default: `8443`)
+- `HAPROXY_SSL_PORT`: HAProxy SSL port (default: `443`)
 - `HAPROXY_SSL_CERT`: Path to SSL certificate for HAProxy
 - `HAPROXY_SSL_OPTS`: SSL options for HAProxy
 
@@ -34,7 +34,7 @@ The following configuration is available through environment variables:
 
 An example run of an Interlock container using the `haproxy` plugin is as follows:
 
-`docker run -p 80:8080 -d ehazlett/interlock --swarm-url tcp://1.2.3.4:2375 --plugin haproxy start`
+`docker run -p 80:80 -d ehazlett/interlock --swarm-url tcp://1.2.3.4:2375 --plugin haproxy start`
 
 Some things to note about this running container:
 
@@ -55,18 +55,18 @@ Some things to note about this running container:
 
 If you used Machine to create your Swarm, you can use this command to start interlock:
 
-`docker run -p 80:8080 -d -v /etc/docker:/etc/docker ehazlett/interlock --swarm-url $DOCKER_HOST --swarm-tls-ca-cert=/etc/docker/ca.pem --swarm-tls-cert=/etc/docker/server.pem --swarm-tls-key=/etc/docker/server-key.pem --plugin haproxy start`
+`docker run -p 80:80 -d -v /etc/docker:/etc/docker ehazlett/interlock --swarm-url $DOCKER_HOST --swarm-tls-ca-cert=/etc/docker/ca.pem --swarm-tls-cert=/etc/docker/server.pem --swarm-tls-key=/etc/docker/server-key.pem --plugin haproxy start`
 
 ## SSL
 
 If you want SSL support, enter a path to the cert (probably want a mounted volume) and then expose 443:
 
-`docker run -p 80:8080 -p 443:8443 -d -v /etc/ssl:/ssl -e HAPROXY_SSL_CERT=/ssl/cert.pem ehazlett/interlock --swarm-url tcp://1.2.3.4:2375 --plugin haproxy start`
+`docker run -p 80:80 -p 443:443 -d -v /etc/ssl:/ssl -e HAPROXY_SSL_CERT=/ssl/cert.pem ehazlett/interlock --swarm-url tcp://1.2.3.4:2375 --plugin haproxy start`
 
 Example for SNI (multidomain) https:
 
 ```
-docker run -it -p 80:8080 -p 443:8443 -d -v /etc/ssl:/etc/ssl -e HAPROXY_SSL_CERT=/etc/ssl/default.crt \
+docker run -it -p 80:80 -p 443:443 -d -v /etc/ssl:/etc/ssl -e HAPROXY_SSL_CERT=/etc/ssl/default.crt \
     -e HAPROXY_SSL_OPTIONS='crt /etc/ssl no-sslv3 ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS' ehazlett/interlock --swarm-url tcp://1.2.3.4:2375 -p haproxy start
 ```
 
@@ -92,6 +92,8 @@ The following options are available:
 - `check_interval`: specify the interval (in ms) when to run the health check (`{"check_interval": 10000}`)  default: 5000
 - `ssl_only`: configure redirect to SSL for backend (`{"ssl_only": true}`)
 - `balance_algorithm`: haproxy balancing algorithm (default: `roundrobin`) http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#balance
+- `ssl_backend`: Configure backend to use SSL (default: `false`)
+- `ssl_backend_tls_verify`: TLS verification mode for backend (`all` or `none`; default: `none`)
 
 For example:
 

--- a/plugins/haproxy/template.go
+++ b/plugins/haproxy/template.go
@@ -23,6 +23,9 @@ defaults
 frontend http-default
     bind *:{{ .PluginConfig.Port }}
     {{ if .PluginConfig.SSLCert }}bind *:{{ .PluginConfig.SSLPort }} ssl crt {{ .PluginConfig.SSLCert }} {{ .PluginConfig.SSLOpts }}{{ end }}
+    # the following is for legacy transition; will be removed in a later version
+    bind *:8080
+    bind *:8443
     monitor-uri /haproxy?monitor
     {{ if .PluginConfig.StatsUser }}stats realm Stats
     stats auth {{ .PluginConfig.StatsUser }}:{{ .PluginConfig.StatsPassword }}{{ end }}

--- a/plugins/haproxy/template.go
+++ b/plugins/haproxy/template.go
@@ -1,0 +1,45 @@
+package haproxy
+
+const (
+	haproxyTmpl = `# managed by interlock
+global
+    {{ if .PluginConfig.SyslogAddr }}log {{ .PluginConfig.SyslogAddr }} local0
+    log-send-hostname{{ end }}
+    maxconn {{ .PluginConfig.MaxConn }}
+    pidfile {{ .PluginConfig.PidPath }}
+
+defaults
+    mode http
+    retries 3
+    option redispatch
+    option httplog
+    option dontlognull
+    option http-server-close
+    option forwardfor
+    timeout connect {{ .PluginConfig.ConnectTimeout }}
+    timeout client {{ .PluginConfig.ClientTimeout }}
+    timeout server {{ .PluginConfig.ServerTimeout }}
+
+frontend http-default
+    bind *:{{ .PluginConfig.Port }}
+    {{ if .PluginConfig.SSLCert }}bind *:{{ .PluginConfig.SSLPort }} ssl crt {{ .PluginConfig.SSLCert }} {{ .PluginConfig.SSLOpts }}{{ end }}
+    monitor-uri /haproxy?monitor
+    {{ if .PluginConfig.StatsUser }}stats realm Stats
+    stats auth {{ .PluginConfig.StatsUser }}:{{ .PluginConfig.StatsPassword }}{{ end }}
+    stats enable
+    stats uri /haproxy?stats
+    stats refresh 5s
+    {{ range $host := .Hosts }}acl is_{{ $host.Name }} hdr_beg(host) {{ $host.Domain }}
+    use_backend {{ $host.Name }} if is_{{ $host.Name }}
+    {{ end }}
+{{ range $host := .Hosts }}backend {{ $host.Name }}
+    http-response add-header X-Request-Start %Ts.%ms
+    balance {{ $host.BalanceAlgorithm }}
+    {{ range $option := $host.BackendOptions }}option {{ $option }}
+    {{ end }}
+    {{ if $host.Check }}option {{ $host.Check }}{{ end }}
+    {{ if $host.SSLOnly }}redirect scheme https if !{ ssl_fc  }{{ end }}
+    {{ range $i,$up := $host.Upstreams }}server {{ $up.Container }} {{ $up.Addr }} check inter {{ $up.CheckInterval }}{{ if $host.SSLBackend }} ssl verify {{ $host.SSLBackendTLSVerify }}{{ end }}
+    {{ end }}
+{{ end }}`
+)

--- a/plugins/nginx/data.go
+++ b/plugins/nginx/data.go
@@ -8,6 +8,7 @@ type InterlockData struct {
 	SSLCert            string   `json:"ssl_certificate,omitempty"`
 	SSLCertKey         string   `json:"ssl_certificate_key,omitempty"`
 	SSLOnly            bool     `json:"ssl_only,omitempty"`
+	SSLBackend         bool     `json:"ssl_backend,omitempty"`
 	Hostname           string   `json:"hostname,omitempty"`
 	Domain             string   `json:"domain,omitempty"`
 	BalanceAlgorithm   string   `json:"balance_algorithm,omitempty"`

--- a/plugins/nginx/host.go
+++ b/plugins/nginx/host.go
@@ -8,6 +8,7 @@ type Host struct {
 	SSLCert            string
 	SSLCertKey         string
 	SSLOnly            bool
+	SSLBackend         bool
 	Upstream           *Upstream
 	WebsocketEndpoints []string
 }

--- a/plugins/nginx/nginx.go
+++ b/plugins/nginx/nginx.go
@@ -301,6 +301,7 @@ func (p NginxPlugin) generateNginxConfig() (*NginxConfig, error) {
 	hostSSLCert := map[string]string{}
 	hostSSLCertKey := map[string]string{}
 	hostSSLOnly := map[string]bool{}
+	hostSSLBackend := map[string]bool{}
 	hostWebsocketEndpoints := map[string][]string{}
 
 	for _, c := range containers {
@@ -357,6 +358,14 @@ func (p NginxPlugin) generateNginxConfig() (*NginxConfig, error) {
 			logMessage(log.DebugLevel,
 				fmt.Sprintf("configuring ssl redirect for %s", domain))
 			hostSSLOnly[domain] = true
+		}
+
+		// check ssl backend
+		hostSSLBackend[domain] = false
+		if interlockData.SSLBackend {
+			logMessage(log.DebugLevel,
+				fmt.Sprintf("configuring ssl backend for %s", domain))
+			hostSSLBackend[domain] = true
 		}
 
 		// set cert paths
@@ -440,6 +449,7 @@ func (p NginxPlugin) generateNginxConfig() (*NginxConfig, error) {
 			SSLCert:            hostSSLCert[k],
 			SSLCertKey:         hostSSLCertKey[k],
 			SSLOnly:            hostSSLOnly[k],
+			SSLBackend:         hostSSLBackend[k],
 			WebsocketEndpoints: hostWebsocketEndpoints[k],
 		}
 

--- a/plugins/nginx/readme.md
+++ b/plugins/nginx/readme.md
@@ -54,6 +54,7 @@ The following options are available:
 - `port`: specify which container port to use for backend (`{"port": 8080}`)
 - `ssl`: configure SSL for backend (`{"ssl": true}`)
 - `ssl_only`: configure redirect to SSL for backend (`{"ssl_only": true}`)
+- `ssl_backend`: configure backend to use SSL (default: `false`)
 - `websocket_endpoints`: list of endpoints to proxy websockets (`{"websocket_endpoints": ["/exec"]}`)
 
 For example:

--- a/plugins/nginx/template.go
+++ b/plugins/nginx/template.go
@@ -73,12 +73,12 @@ http {
         server_name{{ range $name := $host.ServerNames }} {{ $name }}{{ end }};
         {{ if $host.SSLOnly }}return 302 https://$server_name$request_uri;{{ else }}
         location / {
-            proxy_pass http://{{ $host.Upstream.Name }};
+            {{ if $host.SSLBackend }}proxy_pass https://{{ $host.Upstream.Name }};{{ else }}proxy_pass http://{{ $host.Upstream.Name }};{{ end }}
         }
 
         {{ range $ws := $host.WebsocketEndpoints }}
         location {{ $ws }} {
-            proxy_pass http://{{ $host.Upstream.Name }};
+            {{ if $host.SSLBackend }}proxy_pass https://{{ $host.Upstream.Name }};{{ else }}proxy_pass http://{{ $host.Upstream.Name }};{{ end }}
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
@@ -100,12 +100,12 @@ http {
         server_name{{ range $name := $host.ServerNames }} {{ $name }}{{ end }};
 
         location / {
-            proxy_pass http://{{ $host.Upstream.Name }};
+            {{ if $host.SSLBackend }}proxy_pass https://{{ $host.Upstream.Name }};{{ else }}proxy_pass http://{{ $host.Upstream.Name }};{{ end }}
         }
 
         {{ range $ws := $host.WebsocketEndpoints }}
         location {{ $ws }} {
-            proxy_pass http://{{ $host.Upstream.Name }};
+            {{ if $host.SSLBackend }}proxy_pass https://{{ $host.Upstream.Name }};{{ else }}proxy_pass http://{{ $host.Upstream.Name }};{{ end }}
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 var (
-	VERSION = "0.2.11"
+	VERSION = "0.3.0"
 
 	// GITCOMMIT will be overwritten automatically by the build system
 	GITCOMMIT = "HEAD"


### PR DESCRIPTION
This PR does the following:

- Changes the default ports for HAProxy and Nginx to be the same: `80` and `443`
- HAProxy: add support for ssl backends
- Nginx: add support for ssl backends

Closes #55 