### PR TITLE
Export handler and manager.

### DIFF
--- a/manager/handler.go
+++ b/manager/handler.go
@@ -1,4 +1,4 @@
-package main
+package manager
 
 import (
 	"fmt"
@@ -8,18 +8,21 @@ import (
 	"github.com/samalba/dockerclient"
 )
 
+// EventHandler dispatches events to the manager
 type (
 	EventHandler struct {
 		Manager *Manager
 	}
 )
 
+// NewEventHandler registers a Manager on a new EventHandler
 func NewEventHandler(mgr *Manager) *EventHandler {
 	return &EventHandler{
 		Manager: mgr,
 	}
 }
 
+// Handle sends events on to the Manager
 func (l *EventHandler) Handle(e *dockerclient.Event, ec chan error, args ...interface{}) {
 	plugins.Log("interlock", log.DebugLevel,
 		fmt.Sprintf("event: date=%d type=%s image=%s container=%s", e.Time, e.Status, e.From, e.Id))

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1,4 +1,4 @@
-package main
+package manager
 
 import (
 	"crypto/tls"
@@ -18,6 +18,8 @@ var (
 	eventsErrChan = make(chan error)
 )
 
+// Manager listens on events from the connected Docker client and dispatches them
+// to registered plugins
 type (
 	Manager struct {
 		Config    *interlock.Config
@@ -28,6 +30,7 @@ type (
 	}
 )
 
+// NewManager create a new Manager
 func NewManager(cfg *interlock.Config, tlsConfig *tls.Config) *Manager {
 	m := &Manager{
 		Config:    cfg,
@@ -91,6 +94,8 @@ func (m *Manager) reconnectOnFail() {
 	}
 }
 
+// Run starts up the manager, loads plugins, and dispatches a Docker event with
+// status "interlock-start"
 func (m *Manager) Run() error {
 	if err := m.connect(); err != nil {
 		return err
@@ -133,6 +138,7 @@ func (m *Manager) Run() error {
 	return nil
 }
 
+// Stop emits a Docker event with status "interlock-stop"
 func (m *Manager) Stop() error {
 	// custom event to signal shutdown
 	evt := &dockerclient.Event{


### PR DESCRIPTION
To make it easier for me to extend on how interlock gets the original credentials, I needed `handler.go` and `manager.go` to live in a separate namespace/package than `main`.

All this does is shuffle both `handler.go` and `manager.go` over to `github.com/ehazlett/interlock/handlers`. I've added a few comments on exported functions as well.