### PR TITLE
Add listen on TCP port option for HAproxy plugin

### DIFF
--- a/plugins/haproxy/data.go
+++ b/plugins/haproxy/data.go
@@ -11,6 +11,7 @@ type InterlockData struct {
 	Hostname            string   `json:"hostname,omitempty"`
 	Domain              string   `json:"domain,omitempty"`
 	BalanceAlgorithm    string   `json:"balance_algorithm,omitempty"`
+	ListenOnTcpPort     bool     `json:"listen_on_tcp_port,omitempty"`
 
 	// these are custom vals for hosts
 	Check          string   `json:"check,omitempty"`

--- a/plugins/haproxy/proxyconfig.go
+++ b/plugins/haproxy/proxyconfig.go
@@ -11,6 +11,8 @@ type (
 		SSLBackend          bool
 		SSLBackendTLSVerify string
 		BalanceAlgorithm    string
+		ListenOnTcpPort     bool
+		TcpPort             int
 	}
 	Upstream struct {
 		Container     string

--- a/plugins/haproxy/readme.md
+++ b/plugins/haproxy/readme.md
@@ -92,6 +92,7 @@ The following options are available:
 - `check_interval`: specify the interval (in ms) when to run the health check (`{"check_interval": 10000}`)  default: 5000
 - `ssl_only`: configure redirect to SSL for backend (`{"ssl_only": true}`)
 - `balance_algorithm`: haproxy balancing algorithm (default: `roundrobin`) http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#balance
+- `listen_on_tcp_port`: listen on TCP port (`{"listen_on_tcp_port": true}`; default: `false`)
 - `ssl_backend`: Configure backend to use SSL (default: `false`)
 - `ssl_backend_tls_verify`: TLS verification mode for backend (`all` or `none`; default: `none`)
 


### PR DESCRIPTION
The goal of this PR is to allow TCP mode for HAproxy by adding a new option ```ListenOnTcpPort```.