### PR TITLE
fix container build base image reference

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.5-cross
+FROM golang:1.5.3
 RUN go get github.com/tools/godep
 ENV DOCKER_VERSION 1.9
 


### PR DESCRIPTION
changes base image for container build to `golang:1.5.3` to fix issue #71 