### PR TITLE
latest is legacy

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,9 +1,6 @@
 # Getting Started
 Interlock runs as a [Docker](https://www.docker.com) container.  It is distributed as a Docker image and is released on the [Docker Hub](https://hub.docker.com).
 
-Simply run `docker pull ehazlett/interlock:latest` to get the latest Interlock
-image.
-
 # Interlock Options
 ```
 NAME:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,8 @@
 # Getting Started
 Interlock runs as a [Docker](https://www.docker.com) container.  It is distributed as a Docker image and is released on the [Docker Hub](https://hub.docker.com).
 
+Consult the [tags](https://hub.docker.com/r/ehazlett/interlock/tags/) to discover the newest version of interlock and run `docker pull ehazlett/interlock:x.x.x` to get it. The `latest` tag is the legacy version. That is kept for legacy purposes. It is strongly recommended to use the newest version as legacy is no longer maintained.
+
 # Interlock Options
 ```
 NAME:


### PR DESCRIPTION
The [latest tag is actually the legacy version](https://github.com/ehazlett/interlock/blame/master/README.md#L8-L10). I opted to remove `docker pull ehazlett/interlock:latest` rather than do `docker pull ehazlett/interlock:1.0.0` so this file won't have to always be updated every time a new version is pushed.