### PR TITLE
Reorder ssl/sni/verify stanzas

### DIFF
--- a/ext/haproxy/template.go
+++ b/ext/haproxy/template.go
@@ -41,7 +41,7 @@ frontend http-default
     {{ end }}
     {{ if $host.Check }}option {{ $host.Check }}{{ end }}
     {{ if $host.SSLOnly }}redirect scheme https if !{ ssl_fc  }{{ end }}
-    {{ range $i,$up := $host.Upstreams }}server {{ $up.Container }} {{ $up.Addr }} check inter {{ $up.CheckInterval }}{{ if $host.SSLBackend }} ssl sni req.hdr(Host) verify {{ $host.SSLBackendTLSVerify }}{{ end }}
+    {{ range $i,$up := $host.Upstreams }}server {{ $up.Container }} {{ $up.Addr }} check inter {{ $up.CheckInterval }}{{ if $host.SSLBackend }} ssl verify {{ $host.SSLBackendTLSVerify }} sni req.hdr(Host){{ end }}
     {{ end }}
 {{ end }}`
 )


### PR DESCRIPTION
If verify none is set but the verify statement is not located
immediately after SSL, HAProxy will refuse to load the configuration
file as certs are not available.

http://article.gmane.org/gmane.comp.web.haproxy/26894 details this - there looks to be a bug related to the SSL & SNI keywords.