### PR TITLE
Enable Context Roots

### DIFF
--- a/docs/interlock_data.md
+++ b/docs/interlock_data.md
@@ -19,6 +19,7 @@ compatibility.
 |`interlock.ssl_cert_key`           | nginx|
 |`interlock.port`                   | haproxy, nginx|
 |`interlock.context_root`           | haproxy, nginx|
+|`interlock.context_root_rewrite`   | haproxy, nginx|
 |`interlock.websocket_endpoint`     | nginx|
 |`interlock.alias_domain`           | haproxy, nginx|
 |`interlock.health_check`           | haproxy|
@@ -43,3 +44,9 @@ Interlock supports specifying a context root instead of using a hostname.
 Specify a label such as `interlock.context_root=/myapp`.  The upstreams
 will be configured to serve under the context instead of the hostname and
 domain.  The proxy will also rewrite requests so they appear from the root.
+
+By default no rewrite rules will be added.  You can enable rewrites to be added
+by adding the label `interlock.context_root_rewrite=true`.  This will cause
+requests to be rewritten before being sent to the application.  For example,
+if you use a context of `/myapp` and you have rewrite enabled, requests to
+`/myapp/foo` will be rewritten as `/foo`.

--- a/docs/interlock_data.md
+++ b/docs/interlock_data.md
@@ -8,7 +8,7 @@ compatibility.
 
 |Label|Extensions Supported|
 |----|----|
-|`interlock.ext.name`               | common|
+|`interlock.ext.name`               | internal |
 |`interlock.hostname`               | haproxy, nginx|
 |`interlock.domain`                 | haproxy, nginx|
 |`interlock.ssl`                    | nginx|
@@ -18,6 +18,7 @@ compatibility.
 |`interlock.ssl_cert`               | nginx|
 |`interlock.ssl_cert_key`           | nginx|
 |`interlock.port`                   | haproxy, nginx|
+|`interlock.context_root`           | haproxy, nginx|
 |`interlock.websocket_endpoint`     | nginx|
 |`interlock.alias_domain`           | haproxy, nginx|
 |`interlock.health_check`           | haproxy|
@@ -25,3 +26,20 @@ compatibility.
 |`interlock.balance_algorithm`      | haproxy|
 |`interlock.backend_option`         | haproxy|
 
+# Port
+If an upstream container uses multiple ports you can select the port for 
+the proxy to use by specifying the following label: `interlock.port=8080`.
+This will cause the proxy container to use port `8080` when sending requests
+to the upstream containers.
+
+# Alias Domains
+You can specify alias domains to enable the same set of upstream containers
+to serve multiple domains.  To specify an alias domain, specify a label such as
+`interlock.alias_domain=foo.com`.  You can specify multiple by using the
+following syntax: `interlock.alias_domain.0=foo.local`.
+
+# Context Root
+Interlock supports specifying a context root instead of using a hostname.
+Specify a label such as `interlock.context_root=/myapp`.  The upstreams
+will be configured to serve under the context instead of the hostname and
+domain.  The proxy will also rewrite requests so they appear from the root.

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -24,6 +24,7 @@ const (
 	InterlockBalanceAlgorithmLabel    = "interlock.balance_algorithm"      // haproxy
 	InterlockBackendOptionLabel       = "interlock.backend_option"         // haproxy
 	InterlockContextRootLabel         = "interlock.context_root"           // haproxy, nginx
+	InterlockContextRootRewriteLabel  = "interlock.context_root_rewrite"   // haproxy, nginx
 )
 
 type Extension interface {

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -23,6 +23,7 @@ const (
 	InterlockHealthCheckIntervalLabel = "interlock.health_check_interval"  // haproxy
 	InterlockBalanceAlgorithmLabel    = "interlock.balance_algorithm"      // haproxy
 	InterlockBackendOptionLabel       = "interlock.backend_option"         // haproxy
+	InterlockContextRootLabel         = "interlock.context_root"           // haproxy, nginx
 )
 
 type Extension interface {

--- a/ext/lb/haproxy/config.go
+++ b/ext/lb/haproxy/config.go
@@ -4,8 +4,14 @@ import (
 	"github.com/ehazlett/interlock/config"
 )
 
+type ContextRoot struct {
+	Name string
+	Path string
+}
+
 type Host struct {
 	Name                string
+	ContextRoot         *ContextRoot
 	Domain              string
 	Check               string
 	BackendOptions      []string

--- a/ext/lb/haproxy/config.go
+++ b/ext/lb/haproxy/config.go
@@ -12,6 +12,7 @@ type ContextRoot struct {
 type Host struct {
 	Name                string
 	ContextRoot         *ContextRoot
+	ContextRootRewrite  bool
 	Domain              string
 	Check               string
 	BackendOptions      []string

--- a/ext/lb/haproxy/generate.go
+++ b/ext/lb/haproxy/generate.go
@@ -15,6 +15,7 @@ func (p *HAProxyLoadBalancer) GenerateProxyConfig(containers []dockerclient.Cont
 	hostChecks := map[string]string{}
 	hostBalanceAlgorithms := map[string]string{}
 	hostContextRoots := map[string]*ContextRoot{}
+	hostContextRootRewrites := map[string]bool{}
 	hostBackendOptions := map[string][]string{}
 	hostSSLOnly := map[string]bool{}
 	hostSSLBackend := map[string]bool{}
@@ -55,6 +56,7 @@ func (p *HAProxyLoadBalancer) GenerateProxyConfig(containers []dockerclient.Cont
 			Name: contextRootName,
 			Path: contextRoot,
 		}
+		hostContextRootRewrites[domain] = utils.ContextRootRewrite(cInfo.Config)
 
 		healthCheck := utils.HealthCheck(cInfo.Config)
 		healthCheckInterval, err := utils.HealthCheckInterval(cInfo.Config)
@@ -162,6 +164,7 @@ func (p *HAProxyLoadBalancer) GenerateProxyConfig(containers []dockerclient.Cont
 		host := &Host{
 			Name:                name,
 			ContextRoot:         hostContextRoots[k],
+			ContextRootRewrite:  hostContextRootRewrites[k],
 			Domain:              k,
 			Upstreams:           v,
 			Check:               hostChecks[k],

--- a/ext/lb/haproxy/template.go
+++ b/ext/lb/haproxy/template.go
@@ -31,10 +31,18 @@ frontend http-default
     stats enable
     stats uri /haproxy?stats
     stats refresh 5s
-    {{ range $host := .Hosts }}acl is_{{ $host.Name }} hdr_beg(host) {{ $host.Domain }}
+    {{ range $host := .Hosts }}{{ if ne $host.ContextRoot.Path "" }}acl url{{ $host.ContextRoot.Name }} path_beg {{ $host.ContextRoot.Path }}
+    use_backend ctx{{ $host.ContextRoot.Name }} if url{{ $host.ContextRoot.Name }}{{ else }}
+    acl is_{{ $host.Name }} hdr_beg(host) {{ $host.Domain }}
     use_backend {{ $host.Name }} if is_{{ $host.Name }}
     {{ end }}
-{{ range $host := .Hosts }}backend {{ $host.Name }}
+    {{ end }}
+
+{{ range $host := .Hosts }}{{ if ne $host.ContextRoot.Path "" }}backend ctx{{ $host.ContextRoot.Name }}
+    acl missing_slash path_reg ^{{ $host.ContextRoot.Path }}[^/]*$
+    redirect code 301 prefix / drop-query append-slash if missing_slash
+    reqrep ^([^\ :]*)\ {{ $host.ContextRoot.Path }}/(.*)     \1\ /\2{{ else }}
+    backend {{ $host.Name }}{{ end }}
     http-response add-header X-Request-Start %Ts.%ms
     balance {{ $host.BalanceAlgorithm }}
     {{ range $option := $host.BackendOptions }}option {{ $option }}
@@ -43,5 +51,6 @@ frontend http-default
     {{ if $host.SSLOnly }}redirect scheme https if !{ ssl_fc  }{{ end }}
     {{ range $i,$up := $host.Upstreams }}server {{ $up.Container }} {{ $up.Addr }} check inter {{ $up.CheckInterval }}{{ if $host.SSLBackend }} ssl verify {{ $host.SSLBackendTLSVerify }} sni req.hdr(Host){{ end }}
     {{ end }}
-{{ end }}`
+{{ end }}
+`
 )

--- a/ext/lb/haproxy/template.go
+++ b/ext/lb/haproxy/template.go
@@ -41,7 +41,7 @@ frontend http-default
 {{ range $host := .Hosts }}{{ if ne $host.ContextRoot.Path "" }}backend ctx{{ $host.ContextRoot.Name }}
     acl missing_slash path_reg ^{{ $host.ContextRoot.Path }}[^/]*$
     redirect code 301 prefix / drop-query append-slash if missing_slash
-    reqrep ^([^\ :]*)\ {{ $host.ContextRoot.Path }}/(.*)     \1\ /\2{{ else }}
+    {{ if $host.ContextRootRewrite }}reqrep ^([^\ :]*)\ {{ $host.ContextRoot.Path }}/(.*)     \1\ /\2{{ end }}{{ else }}
     backend {{ $host.Name }}{{ end }}
     http-response add-header X-Request-Start %Ts.%ms
     balance {{ $host.BalanceAlgorithm }}

--- a/ext/lb/nginx/config.go
+++ b/ext/lb/nginx/config.go
@@ -22,6 +22,7 @@ type Host struct {
 	ServerNames        []string
 	Port               int
 	ContextRoot        *ContextRoot
+	ContextRootRewrite bool
 	SSLPort            int
 	SSL                bool
 	SSLCert            string

--- a/ext/lb/nginx/config.go
+++ b/ext/lb/nginx/config.go
@@ -12,9 +12,16 @@ type Upstream struct {
 	Name    string
 	Servers []*Server
 }
+
+type ContextRoot struct {
+	Name string
+	Path string
+}
+
 type Host struct {
 	ServerNames        []string
 	Port               int
+	ContextRoot        *ContextRoot
 	SSLPort            int
 	SSL                bool
 	SSLCert            string

--- a/ext/lb/nginx/generate.go
+++ b/ext/lb/nginx/generate.go
@@ -14,6 +14,7 @@ func (p *NginxLoadBalancer) GenerateProxyConfig(containers []dockerclient.Contai
 	upstreamServers := map[string][]string{}
 	serverNames := map[string][]string{}
 	hostContextRoots := map[string]*ContextRoot{}
+	hostContextRootRewrites := map[string]bool{}
 	hostSSL := map[string]bool{}
 	hostSSLCert := map[string]string{}
 	hostSSLCertKey := map[string]string{}
@@ -56,6 +57,7 @@ func (p *NginxLoadBalancer) GenerateProxyConfig(containers []dockerclient.Contai
 			Name: contextRootName,
 			Path: contextRoot,
 		}
+		hostContextRootRewrites[domain] = utils.ContextRootRewrite(cInfo.Config)
 
 		// check if the first server name is there; if not, add
 		// this happens if there are multiple backend containers
@@ -149,6 +151,7 @@ func (p *NginxLoadBalancer) GenerateProxyConfig(containers []dockerclient.Contai
 			ServerNames:        serverNames[k],
 			Port:               p.cfg.Port,
 			ContextRoot:        hostContextRoots[k],
+			ContextRootRewrite: hostContextRootRewrites[k],
 			SSLPort:            p.cfg.SSLPort,
 			SSL:                hostSSL[k],
 			SSLCert:            hostSSLCert[k],

--- a/ext/lb/nginx/template.go
+++ b/ext/lb/nginx/template.go
@@ -66,6 +66,15 @@ http {
                 return 503;
             }
 
+	    {{ range $host := .Hosts }}
+	    {{ if ne $host.ContextRoot.Path "" }}
+	    location {{ $host.ContextRoot.Path }} {
+		rewrite ^([^.]*[^/])$ $1/ permanent;
+		rewrite  ^{{ $host.ContextRoot.Path }}/(.*)  /$1 break;
+		proxy_pass http://ctx{{ $host.ContextRoot.Name }};
+	    }
+	    {{ end }}
+	    {{ end }}
             location /nginx_status {
                 stub_status on;
                 access_log off;
@@ -73,6 +82,13 @@ http {
     }
 
     {{ range $host := .Hosts }}
+    {{ if ne $host.ContextRoot.Path "" }}
+    upstream ctx{{ $host.ContextRoot.Name }} {
+        zone ctx{{ $host.Upstream.Name }}_backend 64k;
+
+        {{ range $up := $host.Upstream.Servers }}server {{ $up.Addr }};
+        {{ end }}
+    }{{ else }}
     upstream {{ $host.Upstream.Name }} {
         zone {{ $host.Upstream.Name }}_backend 64k;
 
@@ -131,7 +147,9 @@ http {
         {{ end }}
     }
     {{ end }}
-    {{ end }}
+
+    {{ end }} {{/* end context root */}}
+    {{ end }} {{/* end host range */}}
 
     include {{ .Config.ConfigBasePath }}/conf.d/*.conf;
 }

--- a/ext/lb/nginx/template.go
+++ b/ext/lb/nginx/template.go
@@ -69,8 +69,8 @@ http {
 	    {{ range $host := .Hosts }}
 	    {{ if ne $host.ContextRoot.Path "" }}
 	    location {{ $host.ContextRoot.Path }} {
-		rewrite ^([^.]*[^/])$ $1/ permanent;
-		rewrite  ^{{ $host.ContextRoot.Path }}/(.*)  /$1 break;
+		{{ if $host.ContextRootRewrite }}rewrite ^([^.]*[^/])$ $1/ permanent;
+		rewrite  ^{{ $host.ContextRoot.Path }}/(.*)  /$1 break;{{ end }}
 		proxy_pass http://ctx{{ $host.ContextRoot.Name }};
 	    }
 	    {{ end }}

--- a/ext/lb/nginx/template_nginxplus.go
+++ b/ext/lb/nginx/template_nginxplus.go
@@ -77,8 +77,8 @@ http {
 	    {{ range $host := .Hosts }}
 	    {{ if ne $host.ContextRoot.Path "" }}
 	    location {{ $host.ContextRoot.Path }} {
-		rewrite ^([^.]*[^/])$ $1/ permanent;
-		rewrite  ^{{ $host.ContextRoot.Path }}/(.*)  /$1 break;
+		{{ if $host.ContextRootRewrite }}rewrite ^([^.]*[^/])$ $1/ permanent;
+		rewrite  ^{{ $host.ContextRoot.Path }}/(.*)  /$1 break;{{ end }}
 		proxy_pass http://ctx{{ $host.ContextRoot.Name }};
 	    }
 	    {{ end }}

--- a/ext/lb/nginx/template_nginxplus.go
+++ b/ext/lb/nginx/template_nginxplus.go
@@ -64,11 +64,12 @@ http {
 
 	    root /usr/share/nginx/html;
 
+	    # nginxplus
     	    location = / {
     	        return 301 /status.html;
     	    }
-
     	    location = /status.html { }
+	    # end nginxplus
 
     	    location /status {
     	        status;

--- a/ext/lb/utils/context_root.go
+++ b/ext/lb/utils/context_root.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"github.com/ehazlett/interlock/ext"
+	"github.com/samalba/dockerclient"
+)
+
+func ContextRoot(config *dockerclient.ContainerConfig) string {
+	if v, ok := config.Labels[ext.InterlockContextRootLabel]; ok {
+		return v
+	}
+
+	return ""
+}

--- a/ext/lb/utils/context_root.go
+++ b/ext/lb/utils/context_root.go
@@ -12,3 +12,11 @@ func ContextRoot(config *dockerclient.ContainerConfig) string {
 
 	return ""
 }
+
+func ContextRootRewrite(config *dockerclient.ContainerConfig) bool {
+	if _, ok := config.Labels[ext.InterlockContextRootRewriteLabel]; ok {
+		return true
+	}
+
+	return false
+}

--- a/ext/lb/utils/context_root_test.go
+++ b/ext/lb/utils/context_root_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/ehazlett/interlock/ext"
+	"github.com/samalba/dockerclient"
+)
+
+func TestContextRoot(t *testing.T) {
+	testContext := "/context"
+
+	cfg := &dockerclient.ContainerConfig{
+		Labels: map[string]string{
+			ext.InterlockContextRootLabel: testContext,
+		},
+	}
+
+	context := ContextRoot(cfg)
+
+	if context != testContext {
+		t.Fatalf("expected %s; received %s", testContext, context)
+	}
+}

--- a/ext/lb/utils/context_root_test.go
+++ b/ext/lb/utils/context_root_test.go
@@ -22,3 +22,17 @@ func TestContextRoot(t *testing.T) {
 		t.Fatalf("expected %s; received %s", testContext, context)
 	}
 }
+
+func TestContextRootRewrite(t *testing.T) {
+	cfg := &dockerclient.ContainerConfig{
+		Labels: map[string]string{
+			ext.InterlockContextRootRewriteLabel: "true",
+		},
+	}
+
+	rewrite := ContextRootRewrite(cfg)
+
+	if !rewrite {
+		t.Fatal("expected context root rewrite")
+	}
+}


### PR DESCRIPTION
This depends on #110.

This adds the ability to use context roots instead of hostnames.  For example, you can add a context root such as `/myapp` and all requests will be available via the proxy using the path `/myapp`.  There is also support for rewrites.