### PR TITLE
Revert "Externalize the extension configuration templates"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 interlock/interlock
 *.swp
-.config/

--- a/cmd/interlock/spec.go
+++ b/cmd/interlock/spec.go
@@ -20,11 +20,12 @@ func specAction(c *cli.Context) {
 		Name:                   "nginx",
 		ConfigPath:             "/etc/conf/nginx.conf",
 		PidPath:                "/etc/conf/nginx.pid",
-		TemplatePath:           "/etc/interlock/nginx.conf.template",
 		BackendOverrideAddress: "",
 	}
 
-	config.SetConfigDefaults(ec)
+	if err := config.SetConfigDefaults(ec); err != nil {
+		log.Fatal(err)
+	}
 
 	cfg := &config.Config{
 		ListenAddr:    ":8080",

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,40 @@
+# sample config for interlock
+ListenAddr = ":8080"
+DockerURL = "unix:///var/run/docker.sock"
+TLSCACert = ""
+TLSCert = ""
+TLSKey = ""
+AllowInsecure = false
+EnableMetrics = true
+
+[[extensions]]
+    Name = "nginx"
+    ConfigPath = "nginx.conf"
+    PidPath = "nginx.pid"
+    BackendOverrideAddress = ""
+    ConnectTimeout = 5000
+    ServerTimeout = 10000
+    ClientTimeout = 10000
+    MaxConn = 1024
+    Port = 80
+    SyslogAddr = ""
+    NginxPlusEnabled = false
+    AdminUser = "admin"
+    AdminPass = ""
+    SSLCertPath = ""
+    SSLCert = ""
+    SSLPort = 0
+    SSLOpts = ""
+    User = "www-data"
+    WorkerProcesses = 2
+    RLimitNoFile = 65535
+    ProxyConnectTimeout = 600
+    ProxySendTimeout = 600
+    ProxyReadTimeout = 600
+    SendTimeout = 600
+    SSLCiphers = "HIGH:!aNULL:!MD5"
+    SSLProtocols = "SSLv3 TLSv1 TLSv1.1 TLSv1.2"
+
+[[extensions]]
+    Name = "beacon"
+    StatInterval = 10

--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,6 @@ type ExtensionConfig struct {
 	ConfigPath             string           // config file path
 	ConfigBasePath         string           `toml:"-"` // internal
 	PidPath                string           // haproxy, nginx
-	TemplatePath           string           // template file path
 	BackendOverrideAddress string           // haproxy, nginx
 	ConnectTimeout         int              // haproxy
 	ServerTimeout          int              // haproxy
@@ -22,6 +21,7 @@ type ExtensionConfig struct {
 	MaxConn                int              // haproxy, nginx
 	Port                   int              // haproxy, nginx
 	SyslogAddr             string           // haproxy
+	NginxPlusEnabled       bool             // nginx
 	AdminUser              string           // haproxy
 	AdminPass              string           // haproxy
 	SSLCertPath            string           // haproxy, nginx

--- a/config/utils.go
+++ b/config/utils.go
@@ -1,58 +1,12 @@
 package config
 
 import (
-	"fmt"
 	"github.com/BurntSushi/toml"
 )
 
-// ParseConfig returns a Config object from a raw string config TOML
-func ParseConfig(data string) (*Config, error) {
-	var cfg Config
-	if _, err := toml.Decode(data, &cfg); err != nil {
-		return nil, err
-	}
-
-	for _, ext := range cfg.Extensions {
-		// setup defaults for missing config entries
-		if err := SetConfigDefaults(ext); err != nil {
-			return nil, err
-		}
-
-		// FIXME: toml isn't being parse right so we hack the rules in like so
-		ext.Rules = cfg.Rules
-	}
-
-	return &cfg, nil
-}
-
 // SetConfigDefaults sets default values if not present
-// ExtensionConfig.Name must be set before calling this function
+// TODO: set config defaults for each extension
 func SetConfigDefaults(c *ExtensionConfig) error {
-	if c.MaxConn == 0 {
-		c.MaxConn = 1024
-	}
-
-	if c.Port == 0 {
-		c.Port = 80
-	}
-
-	switch c.Name {
-	case "haproxy":
-		SetHAProxyConfigDefaults(c)
-	case "nginx":
-		SetNginxConfigDefaults(c)
-	default:
-		return fmt.Errorf("unknown load balancer backend: %s", c.Name)
-	}
-
-	return nil
-}
-
-func SetHAProxyConfigDefaults(c *ExtensionConfig) {
-	if c.TemplatePath == "" {
-		c.TemplatePath = "/etc/interlock/haproxy.cfg.template"
-	}
-
 	if c.ConnectTimeout == 0 {
 		c.ConnectTimeout = 5000
 	}
@@ -65,26 +19,20 @@ func SetHAProxyConfigDefaults(c *ExtensionConfig) {
 		c.ClientTimeout = 10000
 	}
 
+	if c.MaxConn == 0 {
+		c.MaxConn = 1024
+	}
+
+	if c.Port == 0 {
+		c.Port = 80
+	}
+
 	if c.AdminUser == "" {
 		c.AdminUser = "admin"
 	}
 
 	if c.AdminPass == "" {
 		c.AdminPass = ""
-	}
-
-	if c.SSLDefaultDHParam == 0 {
-		c.SSLDefaultDHParam = 1024
-	}
-
-	if c.SSLServerVerify == "" {
-		c.SSLServerVerify = "required"
-	}
-}
-
-func SetNginxConfigDefaults(c *ExtensionConfig) {
-	if c.TemplatePath == "" {
-		c.TemplatePath = "/etc/interlock/nginx.conf.template"
 	}
 
 	if c.User == "" {
@@ -122,4 +70,38 @@ func SetNginxConfigDefaults(c *ExtensionConfig) {
 	if c.SSLProtocols == "" {
 		c.SSLProtocols = "SSLv3 TLSv1 TLSv1.1 TLSv1.2"
 	}
+
+	if c.SSLDefaultDHParam == 0 {
+		c.SSLDefaultDHParam = 1024
+	}
+
+	if c.SSLServerVerify == "" {
+		c.SSLServerVerify = "required"
+	}
+
+	if c.StatInterval == 0 {
+		c.StatInterval = 60
+	}
+
+	return nil
+}
+
+// ParseConfig returns a Config object from a raw string config TOML
+func ParseConfig(data string) (*Config, error) {
+	var cfg Config
+	if _, err := toml.Decode(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	for _, ext := range cfg.Extensions {
+		// setup defaults for missing config entries
+		if err := SetConfigDefaults(ext); err != nil {
+			return nil, err
+		}
+
+		// FIXME: toml isn't being parse right so we hack the rules in like so
+		ext.Rules = cfg.Rules
+	}
+
+	return &cfg, nil
 }

--- a/config/utils_test.go
+++ b/config/utils_test.go
@@ -28,110 +28,18 @@ func TestParseConfig(t *testing.T) {
 
 func TestSetConfigDefaults(t *testing.T) {
 	cfg := &ExtensionConfig{
-		Name: "nginx",
+		Name: "test",
 	}
 
 	if err := SetConfigDefaults(cfg); err != nil {
 		t.Fatal(err)
-	}
-
-	if cfg.MaxConn != 1024 {
-		t.Fatalf("expected default max connections of 1024; received %d", cfg.MaxConn)
-	}
-
-	if cfg.Port != 80 {
-		t.Fatalf("expected default port of 80; received %d", cfg.Port)
-	}
-}
-
-func TestSetNginxConfigDefaults(t *testing.T) {
-	cfg := &ExtensionConfig{
-		Name: "nginx",
-	}
-
-	if err := SetConfigDefaults(cfg); err != nil {
-		t.Fatal(err)
-	}
-
-	if cfg.TemplatePath != "/etc/interlock/nginx.conf.template" {
-		t.Fatalf("expected default template path of /etc/interlock/nginx.conf.template; received %d", cfg.TemplatePath)
-	}
-
-	if cfg.User != "www-data" {
-		t.Fatalf("expected default user of www-data; received %d", cfg.User)
-	}
-
-	if cfg.WorkerProcesses != 2 {
-		t.Fatalf("expected default worker processes of 2; received %d", cfg.WorkerProcesses)
-	}
-
-	if cfg.RLimitNoFile != 65535 {
-		t.Fatalf("expected default rlimit no file of 65535; received %d", cfg.RLimitNoFile)
-	}
-
-	if cfg.ProxyConnectTimeout != 600 {
-		t.Fatalf("expected default proxy connect timeout of 600; received %d", cfg.ProxyConnectTimeout)
-	}
-
-	if cfg.ProxySendTimeout != 600 {
-		t.Fatalf("expected default proxy send timeout of 600; received %d", cfg.ProxySendTimeout)
-	}
-
-	if cfg.ProxyReadTimeout != 600 {
-		t.Fatalf("expected default proxy read timeout of 600; received %d", cfg.ProxyReadTimeout)
-	}
-
-	if cfg.SendTimeout != 600 {
-		t.Fatalf("expected default send timeout of 600; received %d", cfg.SendTimeout)
-	}
-
-	if cfg.SSLCiphers != "HIGH:!aNULL:!MD5" {
-		t.Fatalf("expected default SSL ciphers of HIGH:!aNULL:!MD5; received %d", cfg.SSLCiphers)
-	}
-
-	if cfg.SSLProtocols != "SSLv3 TLSv1 TLSv1.1 TLSv1.2" {
-		t.Fatalf("expected default SSL protocols of SSLv3 TLSv1 TLSv1.1 TLSv1.2; received %d", cfg.SSLProtocols)
-	}
-}
-
-func TestSetHAProxyConfigDefaults(t *testing.T) {
-	cfg := &ExtensionConfig{
-		Name: "haproxy",
-	}
-
-	if err := SetConfigDefaults(cfg); err != nil {
-		t.Fatal(err)
-	}
-
-	if cfg.TemplatePath != "/etc/interlock/haproxy.cfg.template" {
-		t.Fatalf("expected default template path of /etc/interlock/haproxy.cfg.template; received %d", cfg.TemplatePath)
 	}
 
 	if cfg.ConnectTimeout != 5000 {
 		t.Fatalf("expected default connect timeout of 5000; received %d", cfg.ConnectTimeout)
 	}
 
-	if cfg.ServerTimeout != 10000 {
-		t.Fatalf("expected default server timeout of 10000; received %d", cfg.ServerTimeout)
-	}
-
-	if cfg.ClientTimeout != 10000 {
-		t.Fatalf("expected default client timeout of 10000; received %d", cfg.ClientTimeout)
-	}
-
-	if cfg.AdminUser != "admin" {
-		t.Fatalf("expected default admin user of admin; received %d", cfg.AdminUser)
-	}
-
-	if cfg.AdminPass != "" {
-		t.Fatalf("expected default admin password of \"\"; received %d", cfg.AdminPass)
-	}
-
-	if cfg.SSLDefaultDHParam != 1024 {
-		t.Fatalf("expected default SSL default DH param of 1024; received %d", cfg.SSLDefaultDHParam)
-	}
-
-	if cfg.SSLServerVerify != "required" {
-		t.Fatalf("expected default SSL server verify of required; received %d", cfg.SSLServerVerify)
+	if cfg.MaxConn != 1024 {
+		t.Fatalf("expected default max connections of 1024; received %d", cfg.MaxConn)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,13 +1,7 @@
 # Configuration
+Interlock uses a configuration store (file/kv) to configure options and extensions.
 
-Interlock uses a configuration store to configure options and extensions. The configuration store can be one of:
-
-* File
-* Environment variable
-* Key value store
-
-## File configuration
-
+# Example Configuration
 ```
 ListenAddr = ":8080"
 DockerURL = "unix:///var/run/docker.sock"
@@ -19,14 +13,22 @@ EnableMetrics = true
 
 [[Extensions]]
   Name = "nginx"
-  ConfigPath = "/etc/nginx/nginx.conf"
-  PidPath = "/etc/nginx/nginx.pid"
-  TemplatePath = "/etc/interlock/nginx.conf.template"
+  ConfigPath = "/etc/conf/nginx.conf"
+  PidPath = "/etc/conf/nginx.pid"
   BackendOverrideAddress = ""
+  ConnectTimeout = 5000
+  ServerTimeout = 10000
+  ClientTimeout = 10000
   MaxConn = 1024
   Port = 80
+  SyslogAddr = ""
+  NginxPlusEnabled = false
+  AdminUser = "admin"
+  AdminPass = ""
   SSLCertPath = ""
+  SSLCert = ""
   SSLPort = 0
+  SSLOpts = ""
   User = "www-data"
   WorkerProcesses = 2
   RLimitNoFile = 65535
@@ -38,14 +40,48 @@ EnableMetrics = true
   SSLProtocols = "SSLv3 TLSv1 TLSv1.1 TLSv1.2"
 ```
 
-# Environment variable configuration
-
+# Environment
 You can also put the config as text in the environment variable 
 `INTERLOCK_CONFIG`.  If you pass command flags they will override the
 environment data.
 
-# Key value store configuration
+# Reference
+The following table lists all options, their type and the extensions in which
+they are compatible:
 
+|Option|Type|Extensions Supported|
+|----|----|----|
+|Name                   | string | extension name |
+|ConfigPath             | string | config file path |
+|PidPath                | string | haproxy, nginx |
+|BackendOverrideAddress | string | haproxy, nginx |
+|ConnectTimeout         | int    | haproxy |
+|ServerTimeout          | int    | haproxy |
+|ClientTimeout          | int    | haproxy |
+|MaxConn                | int    | haproxy, nginx |
+|Port                   | int    | haproxy, nginx |
+|SyslogAddr             | string | haproxy |
+|NginxPlusEnabled       | bool   | nginx |
+|AdminUser              | string | haproxy |
+|AdminPass              | string | haproxy |
+|SSLCertPath            | string | haproxy, nginx |
+|SSLCert                | string | haproxy |
+|SSLPort                | int    | haproxy, nginx |
+|SSLOpts                | string | haproxy |
+|SSLServerVerify        | string | haproxy |
+|SSLDefaultDHParam      | int    | haproxy |
+|User                   | string | nginx |
+|WorkerProcesses        | int    | nginx |
+|RLimitNoFile           | int    | nginx |
+|ProxyConnectTimeout    | int    | nginx |
+|ProxySendTimeout       | int    | nginx |
+|ProxyReadTimeout       | int    | nginx |
+|SendTimeout            | int    | nginx |
+|SSLCiphers             | string | nginx |
+|SSLProtocols           | string | nginx |
+|StatInterval           | int    | beacon |
+
+# Key Value Storage Support
 Interlock supports etcd and consul [libkv](https://github.com/docker/libkv)
 key-value store backends.  This can be used to store the configuration instead
 of the file.  This is useful when deploying several instances of Interlock
@@ -65,7 +101,6 @@ DockerURL = "tcp://127.0.0.1:2376"
   Name = "haproxy"
   ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"
   PidPath = "/usr/local/etc/haproxy/haproxy.pid"
-  TemplatePath = "/usr/local/etc/interlock/haproxy.cfg.template"
   MaxConn = 1024
   Port = 80'
 ```
@@ -74,39 +109,3 @@ You can then start Interlock and point it at the KV store:
 
 `docker run -ti -d --net=host ehazlett/interlock run --discovery etcd://1.2.3.4:4001`
 
-# Reference
-
-The following table lists all options, their type and the extensions in which
-they are compatible:
-
-|Option|Type|Extensions Supported|
-|----|----|----|
-|Name                   | string | extension name |
-|ConfigPath             | string | config file path |
-|PidPath                | string | haproxy, nginx |
-|TemplatePath           | string | haproxy, nginx |
-|BackendOverrideAddress | string | haproxy, nginx |
-|ConnectTimeout         | int    | haproxy |
-|ServerTimeout          | int    | haproxy |
-|ClientTimeout          | int    | haproxy |
-|MaxConn                | int    | haproxy, nginx |
-|Port                   | int    | haproxy, nginx |
-|SyslogAddr             | string | haproxy |
-|AdminUser              | string | haproxy |
-|AdminPass              | string | haproxy |
-|SSLCertPath            | string | haproxy, nginx |
-|SSLCert                | string | haproxy |
-|SSLPort                | int    | haproxy, nginx |
-|SSLOpts                | string | haproxy |
-|SSLServerVerify        | string | haproxy |
-|SSLDefaultDHParam      | int    | haproxy |
-|User                   | string | nginx |
-|WorkerProcesses        | int    | nginx |
-|RLimitNoFile           | int    | nginx |
-|ProxyConnectTimeout    | int    | nginx |
-|ProxySendTimeout       | int    | nginx |
-|ProxyReadTimeout       | int    | nginx |
-|SendTimeout            | int    | nginx |
-|SSLCiphers             | string | nginx |
-|SSLProtocols           | string | nginx |
-|StatInterval           | int    | beacon |

--- a/docs/examples/haproxy/config.toml
+++ b/docs/examples/haproxy/config.toml
@@ -3,9 +3,8 @@ DockerURL = "unix:///var/run/docker.sock"
 
 [[Extensions]]
 Name = "haproxy"
-ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"
-PidPath = "/usr/local/etc/haproxy/haproxy.pid"
-TemplatePath = "/etc/interlock/haproxy.cfg.template"
+ConfigPath = "/usr/local/etc/haproxy.cfg"
+PidPath = "/etc/haproxy.pid"
 BackendOverrideAddress = "172.17.0.1"
 MaxConn = 1024
 Port = 80

--- a/docs/examples/haproxy/docker-compose.yml
+++ b/docs/examples/haproxy/docker-compose.yml
@@ -1,10 +1,10 @@
 interlock:
     image: ehazlett/interlock:1.1.0
-    command: run -c /etc/interlock/config.toml
+    command: run -c /bin/config.toml
     ports:
         - 8080
     volumes:
-        - ./config.toml:/etc/interlock/config.toml
+        - ./config.toml:/bin/config.toml
         - /var/run/docker.sock:/var/run/docker.sock
 
 haproxy:

--- a/docs/examples/nginx-swarm-machine/docker-compose.yml
+++ b/docs/examples/nginx-swarm-machine/docker-compose.yml
@@ -1,6 +1,6 @@
 interlock:
     image: ehazlett/interlock:1.1.0
-    command: -D run -c /etc/interlock/config.toml
+    command: -D run
     tty: true
     ports:
         - 8080
@@ -16,12 +16,11 @@ interlock:
             Name = "nginx"
             ConfigPath = "/etc/nginx/nginx.conf"
             PidPath = "/etc/nginx/nginx.pid"
-            TemplatePath = "/etc/interlock/nginx.conf.template"
             MaxConn = 1024
             Port = 80
     volumes:
         - /var/lib/boot2docker:/var/lib/boot2docker:ro
-        - /var/tmp/config.toml:/etc/interlock/config.toml
+        - /var/tmp/config.toml:/bin/config.toml
 
 nginx:
     image: nginx:latest

--- a/docs/examples/nginx-swarm/config.toml
+++ b/docs/examples/nginx-swarm/config.toml
@@ -3,8 +3,7 @@ DockerURL = "tcp://127.0.0.1:3375"
 
 [[Extensions]]
 Name = "nginx"
-ConfigPath = "/etc/nginx/nginx.conf"
-PidPath = "/etc/nginx/nginx.pid"
-TemplatePath = "/etc/interlock/nginx.conf.template"
+ConfigPath = "/etc/conf/nginx.conf"
+PidPath = "/etc/conf/nginx.pid"
 MaxConn = 1024
 Port = 80

--- a/docs/examples/nginx-swarm/docker-compose.yml
+++ b/docs/examples/nginx-swarm/docker-compose.yml
@@ -1,16 +1,16 @@
 interlock:
     image: ehazlett/interlock:1.1.0
-    command: run -c /etc/interlock/config.toml
+    command: run -c /bin/config.toml
     ports:
         - 8080
     volumes:
-        - ./config.toml:/etc/interlock/config.toml
-        - nginx:/etc/nginx
+        - ./config.toml:/bin/config.toml
+        - nginx:/etc/conf
 
 nginx:
     image: nginx:latest
     entrypoint: nginx
-    command: -g "daemon off;" -c /etc/nginx/nginx.conf
+    command: -g "daemon off;" -c /etc/conf/nginx.conf
     ports:
         - 80:80
     labels:
@@ -18,7 +18,7 @@ nginx:
     links:
         - interlock:interlock
     volumes:
-        - nginx:/etc/nginx
+        - nginx:/etc/conf
 
 app:
     image: ehazlett/docker-demo:latest

--- a/docs/examples/nginx/config.toml
+++ b/docs/examples/nginx/config.toml
@@ -4,8 +4,7 @@ DockerURL = "unix:///var/run/docker.sock"
 [[extensions]]
 Name = "nginx"
 ConfigPath = "/etc/nginx/nginx.conf"
-PidPath = "/etc/nginx/nginx.pid"
-TemplatePath = "/etc/interlock/nginx.conf.template"
+PidPath = "/tmp/nginx.pid"
 BackendOverrideAddress = "172.17.0.1"
 MaxConn = 1024
 Port = 80

--- a/docs/examples/nginx/docker-compose.yml
+++ b/docs/examples/nginx/docker-compose.yml
@@ -1,10 +1,10 @@
 interlock:
     image: ehazlett/interlock:1.1.0
-    command: run -c /etc/interlock/config.toml
+    command: run -c /bin/config.toml
     ports:
         - 8080
     volumes:
-        - ./config.toml:/etc/interlock/config.toml
+        - ./config.toml:/bin/config.toml
         - /var/run/docker.sock:/var/run/docker.sock
 
 nginx:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,6 +52,11 @@ This will get a quick Interlock + Nginx load balancer.
 Note: It is recommended to use [Swarm](https://www.docker.com/products/docker-swarm) as Interlock will handle updating the configuration with the proper
 Swarm node.  If you do not use Swarm, you will need to set the `BackendOverrideAddress` option to a resolvable IP address so Nginx knows which node to route the request.  In the example below, we will use the Docker socket for simplicity.
 
+# Config Volume
+Create a volume for the Nginx config:
+
+`docker volume create --name nginx`
+
 # Interlock Config
 Create the Interlock config `config.toml`:
 
@@ -61,8 +66,8 @@ DockerURL = "unix:///var/run/docker.sock"
 
 [[Extensions]]
   Name = "nginx"
-  ConfigPath = "/etc/nginx/nginx.conf"
-  PidPath = "/etc/nginx/nginx.pid"
+  ConfigPath = "/etc/conf/nginx.conf"
+  PidPath = "/etc/conf/nginx.pid"
   BackendOverrideAddress = "172.17.0.1"
 ```
 
@@ -73,10 +78,11 @@ docker run \
     -P \
     -d \
     -ti \
+    -v nginx:/etc/conf \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $(pwd)/config.toml:/etc/interlock/config.toml \
+    -v $(pwd)/config.toml:/etc/config.toml \
     ehazlett/interlock:1.0.0 \
-    -D run -c /etc/interlock/config.toml
+    -D run -c /etc/config.toml
 
 ```
 
@@ -88,8 +94,9 @@ docker run \
     -d \
     --net=host \
     --label interlock.ext.name=nginx \
+    -v nginx:/etc/conf \
     nginx \
-    nginx -g "daemon off;" -c /etc/nginx/nginx.conf
+    nginx -g "daemon off;" -c /etc/conf/nginx.conf
 ```
 
 # Interlock
@@ -100,7 +107,7 @@ You can now start some containers with exposed ports to see Interlock add them t
 ```
 INFO[0000] interlock 1.0.0
 DEBU[0000] docker client: url=unix:///var/run/docker.sock 
-DEBU[0000] loading extension: name=nginx configpath=/etc/nginx/nginx.conf 
+DEBU[0000] loading extension: name=nginx configpath=/etc/conf/nginx.conf 
 DEBU[0000] updating load balancers                      
 INFO[0000] configuration updated                         ext=nginx
 DEBU[0077] container start: id=bc9c4f2b9a8697406377191ade8a187c80ef37d9cb59391e1e14608e974 image=nginx 

--- a/ext/lb/haproxy/haproxy.go
+++ b/ext/lb/haproxy/haproxy.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/ehazlett/interlock/config"
 	"github.com/samalba/dockerclient"
-	"io/ioutil"
 )
 
 const (
@@ -44,13 +43,7 @@ func (p *HAProxyLoadBalancer) ConfigPath() string {
 }
 
 func (p *HAProxyLoadBalancer) Template() string {
-	d, err := ioutil.ReadFile(p.cfg.TemplatePath)
-
-	if err == nil {
-		return string(d)
-	} else {
-		return err.Error()
-	}
+	return haproxyConfTemplate
 }
 
 func (p *HAProxyLoadBalancer) Reload(proxyContainers []dockerclient.Container) error {

--- a/ext/lb/haproxy/template.go
+++ b/ext/lb/haproxy/template.go
@@ -1,4 +1,7 @@
-# managed by interlock
+package haproxy
+
+const (
+	haproxyConfTemplate = `# managed by interlock
 global
     {{ if .Config.SyslogAddr }}log {{ .Config.SyslogAddr }} local0
     log-send-hostname{{ end }}
@@ -49,3 +52,5 @@ frontend http-default
     {{ range $i,$up := $host.Upstreams }}server {{ $up.Container }} {{ $up.Addr }} check inter {{ $up.CheckInterval }}{{ if $host.SSLBackend }} ssl verify {{ $host.SSLBackendTLSVerify }} sni req.hdr(Host){{ end }}
     {{ end }}
 {{ end }}
+`
+)

--- a/ext/lb/lb.go
+++ b/ext/lb/lb.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ehazlett/interlock/ext/lb/nginx"
 	"github.com/ehazlett/ttlcache"
 	"github.com/samalba/dockerclient"
-	"os"
 )
 
 const (
@@ -66,13 +65,6 @@ type eventArgs struct {
 }
 
 func NewLoadBalancer(c *config.ExtensionConfig, client *dockerclient.DockerClient) (*LoadBalancer, error) {
-	if _, err := os.Stat(c.TemplatePath); os.IsNotExist(err) {
-		log().Errorf("Missing %s configuration template: file=%s", c.Name, c.TemplatePath)
-		log().Errorf("Use the TemplatePath option in your Interlock config.toml to set a custom location for the %s configuration template", c.Name)
-		log().Errorf("Examples of an configuration template: url=https://github.com/ehazlett/interlock/tree/master/docs/examples/%s", c.Name)
-		log().Fatal(err)
-	}
-
 	// parse config base dir
 	c.ConfigBasePath = filepath.Dir(c.ConfigPath)
 

--- a/ext/lb/nginx/nginx.go
+++ b/ext/lb/nginx/nginx.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/ehazlett/interlock/config"
 	"github.com/samalba/dockerclient"
-	"io/ioutil"
 )
 
 const (
@@ -45,13 +44,11 @@ func (p *NginxLoadBalancer) HandleEvent(event *dockerclient.Event) error {
 }
 
 func (p *NginxLoadBalancer) Template() string {
-	d, err := ioutil.ReadFile(p.cfg.TemplatePath)
-
-	if err == nil {
-		return string(d)
-	} else {
-		return err.Error()
+	if p.cfg.NginxPlusEnabled {
+		return nginxPlusConfTemplate
 	}
+
+	return nginxConfTemplate
 }
 
 func (p *NginxLoadBalancer) ConfigPath() string {
@@ -59,7 +56,7 @@ func (p *NginxLoadBalancer) ConfigPath() string {
 }
 
 func (p *NginxLoadBalancer) Reload(proxyContainers []dockerclient.Container) error {
-	// restart all interlock managed nginx containers
+	// restart all interlock managed haproxy containers
 	for _, cnt := range proxyContainers {
 		// restart
 		if err := p.client.KillContainer(cnt.Id, "HUP"); err != nil {

--- a/ext/lb/nginx/template.go
+++ b/ext/lb/nginx/template.go
@@ -1,4 +1,6 @@
-# managed by interlock
+package nginx
+
+var nginxConfTemplate = `# managed by interlock
 user  {{ .Config.User }};
 worker_processes  {{ .Config.WorkerProcesses }};
 worker_rlimit_nofile {{ .Config.RLimitNoFile }};
@@ -151,3 +153,4 @@ http {
 
     include {{ .Config.ConfigBasePath }}/conf.d/*.conf;
 }
+`

--- a/ext/lb/nginx/template_nginxplus.go
+++ b/ext/lb/nginx/template_nginxplus.go
@@ -1,4 +1,6 @@
-# managed by interlock
+package nginx
+
+var nginxPlusConfTemplate = `# managed by interlock
 user  {{ .Config.User }};
 worker_processes  {{ .Config.WorkerProcesses }};
 worker_rlimit_nofile {{ .Config.RLimitNoFile }};
@@ -156,3 +158,4 @@ http {
 
     include {{ .Config.ConfigBasePath }}/conf.d/*.conf;
 }
+`


### PR DESCRIPTION
I missed some manual testing and this breaks all existing installations of Interlock.  Reverting.