### PR TITLE
change getNodeID into getContainerID and modify implementation

### DIFF
--- a/ext/lb/lb.go
+++ b/ext/lb/lb.go
@@ -89,20 +89,20 @@ func NewLoadBalancer(c *config.ExtensionConfig, client *dockerclient.DockerClien
 		lbUpdateChan <- true
 	})
 
-	// load nodeID
-	nodeID, err := getNodeID()
+	// load containerID for the following nodeID
+	containerID, err := getContainerID()
 	if err != nil {
 		return nil, err
 	}
 
-	log().Infof("interlock node: id=%s", nodeID)
+	log().Infof("interlock node: container id=%s", containerID)
 
 	extension := &LoadBalancer{
 		cfg:    c,
 		client: client,
 		cache:  cache,
 		lock:   &sync.Mutex{},
-		nodeID: nodeID,
+		nodeID: containerID,
 	}
 
 	// select backend
@@ -254,7 +254,7 @@ func NewLoadBalancer(c *config.ExtensionConfig, client *dockerclient.DockerClien
 
 			for _, cnt := range containers {
 				// always include self container
-				if cnt.Id == nodeID {
+				if cnt.Id == containerID {
 					interlockNodes = append(interlockNodes, cnt)
 					continue
 				}

--- a/ext/lb/utils.go
+++ b/ext/lb/utils.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func getNodeID() (string, error) {
+func getContainerID() (string, error) {
 	f, err := os.Open("/proc/self/cgroup")
 	if err != nil {
 		return "", fmt.Errorf("unable to detect cgroup.  are you sure you are in a container? error: %s", err)
@@ -33,11 +33,11 @@ func getNodeID() (string, error) {
 		}
 
 		id = dataParts[2]
+
+		if id != "" {
+			return strings.TrimSpace(id), nil
+		}
 	}
 
-	if id == "" {
-		return "", fmt.Errorf("unable to get node id")
-	}
-
-	return strings.TrimSpace(id), nil
+	return "", fmt.Errorf("unable to get container id")
 }

--- a/ext/lb/utils_test.go
+++ b/ext/lb/utils_test.go
@@ -6,17 +6,17 @@ import (
 	"testing"
 )
 
-func TestGetNodeID(t *testing.T) {
+func TestGetContainerID(t *testing.T) {
 	if _, err := os.Stat("/proc/self/cgroup"); err != nil {
 		if os.IsNotExist(err) {
-			t.Skipf("skipping GetNodeID; does not look like i am in a container")
+			t.Skipf("skipping GetContainerID; does not look like I am in a container")
 		}
 	}
 
-	id, err := getNodeID()
+	id, err := getContainerID()
 	if err != nil {
 		if err == io.EOF {
-			t.Skipf("skipping GetNodeID; does not look like i am in a normal container")
+			t.Skipf("skipping GetContainerID; does not look like I am in a normal container")
 		}
 
 		t.Fatal(err)


### PR DESCRIPTION
this pr did these things below:
1. change `getNodeID` into `getContainerID` to make it more readable,
2. change implementation of getContainerID, return immediately when get non-empty id 
3. change `getNodeID` into `getContainerID` in utils_test.go

Signed-off-by: allencloud allen.sun@daocloud.io
