### PR TITLE
503 SSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,3 @@ clean:
 	@rm cmd/$(APP)/$(APP)
 
 .PHONY: deps build build-static build-app build-image image clean test
-

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,10 @@ type ExtensionConfig struct {
 	SSLCiphers             string           // nginx
 	SSLProtocols           string           // nginx
 	StatInterval           int              // beacon
+	DefaultHostSSL         bool             // nginx
+	DefaultSSLPort         int              // nginx
+	DefaultHostSSLKeyPath  string           // nginx
+	DefaultHostSSLCrtPath  string           // nginx
 	Rules                  map[string]*Rule // beacon FIXME: this isn't loaded properly from toml; we set it as a hack now
 }
 


### PR DESCRIPTION
This would allow users to be routed to a 503 page if they were previously on a site with HTTPS enabled but was taken offline.  

Solves https://github.com/ehazlett/interlock/issues/164
