### PR TITLE
Modify the iptables.go  to fix some bugs

### DIFF
--- a/ext/lb/haproxy/iptables.go
+++ b/ext/lb/haproxy/iptables.go
@@ -70,7 +70,7 @@ func (p *HAProxyLoadBalancer) dropSYN() error {
 func (p *HAProxyLoadBalancer) resumeSYN() error {
 	log().Debug("resuming SYN packets")
 
-	if err := p.configIPTables(false); err != nil {
+	if err := p.configIPTables(true); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The parameter in line 73, `if err := p.configIPTables(false); err != nil {` should be `if err := p.configIPTables(true); err != nil {`