### PR TITLE
Added fix for issue #220 don't collect interlock containers that are …

### DIFF
--- a/ext/lb/lb.go
+++ b/ext/lb/lb.go
@@ -276,6 +276,10 @@ func NewLoadBalancer(c *config.ExtensionConfig, client *client.Client) (*LoadBal
 			interlockNodes := []types.Container{}
 
 			for _, cnt := range containers {
+				if cnt.State != "running" {
+					continue
+				}
+				
 				// always include self container
 				if cnt.ID == containerID && cnt.State == "running" {
 					interlockNodes = append(interlockNodes, cnt)


### PR DESCRIPTION
The loop will include containers that are not running. This causes a problem later on when the load balancer containers are distributed across interlock nodes. An nginx container would get assigned to a stopped interlock and therefore never be reloaded.